### PR TITLE
Add check_only_top_of_status_code to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ google:
   api_token: "AAAAAAAA"
   channel: "#general"
   user_name: "zatsu_monitor"
+  # check_only_top_of_status_code: true
 github:
   type: chatwork
   check_url: "https://github.com/"
   api_token: "AAAAAAAA"
   room_id: "111111"
+  # check_only_top_of_status_code: true
 ```
 
 ### Detail
@@ -66,6 +68,10 @@ github:
 * `check_url` : URL for checking (required)
 * `api_token` : ChatWork API Token (required)
 * `room_id` : RoomID for post (required)
+
+#### Common
+* `check_only_top_of_status_code` : Whether check only top of the status code (optional. default is `false`)
+  * e.g) When `check_only_top_of_status_code` is `true`, before status code is 501 and current status code is 502, don't notify
 
 ## ProTip
 ### Inherit values

--- a/config_test.go
+++ b/config_test.go
@@ -72,9 +72,14 @@ func TestLoadConfigFromFile(t *testing.T) {
 	assert.Equal(t, "xoxp-0000000000-0000000000-0000000000-000000", config["name1"]["api_token"])
 	assert.Equal(t, "zatsu_monitor", config["name1"]["user_name"])
 	assert.Equal(t, "#general", config["name1"]["channel"])
+	assert.Equal(t, "", config["name1"]["only_check_on_the_order_of_100"])
 
 	assert.Equal(t, "http://example.com/2", config["name2"]["check_url"])
 	assert.Equal(t, "chatwork", config["name2"]["type"])
 	assert.Equal(t, "AAAAAAAA", config["name2"]["api_token"])
 	assert.Equal(t, "111111", config["name2"]["room_id"])
+
+	assert.Equal(t, "true", config["name3"]["only_check_on_the_order_of_100"])
+
+	assert.Equal(t, "false", config["name4"]["only_check_on_the_order_of_100"])
 }

--- a/config_test.go
+++ b/config_test.go
@@ -72,14 +72,14 @@ func TestLoadConfigFromFile(t *testing.T) {
 	assert.Equal(t, "xoxp-0000000000-0000000000-0000000000-000000", config["name1"]["api_token"])
 	assert.Equal(t, "zatsu_monitor", config["name1"]["user_name"])
 	assert.Equal(t, "#general", config["name1"]["channel"])
-	assert.Equal(t, "", config["name1"]["only_check_on_the_order_of_100"])
+	assert.Equal(t, "", config["name1"]["check_only_top_of_status_code"])
 
 	assert.Equal(t, "http://example.com/2", config["name2"]["check_url"])
 	assert.Equal(t, "chatwork", config["name2"]["type"])
 	assert.Equal(t, "AAAAAAAA", config["name2"]["api_token"])
 	assert.Equal(t, "111111", config["name2"]["room_id"])
 
-	assert.Equal(t, "true", config["name3"]["only_check_on_the_order_of_100"])
+	assert.Equal(t, "true", config["name3"]["check_only_top_of_status_code"])
 
-	assert.Equal(t, "false", config["name4"]["only_check_on_the_order_of_100"])
+	assert.Equal(t, "false", config["name4"]["check_only_top_of_status_code"])
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,12 @@ func perform(name string, values map[string]string) {
 		panic(err)
 	}
 
-	if isNotify(beforeStatusCode, currentStatusCode) {
+	onlyCheckOnTheOrderOf100 := false
+	if values["only_check_on_the_order_of_100"] == "true" {
+		onlyCheckOnTheOrderOf100 = true
+	}
+
+	if isNotify(beforeStatusCode, currentStatusCode, onlyCheckOnTheOrderOf100) {
 		// When status code changes from the previous, notify
 		param := PostStatusParam{
 			CheckUrl:          checkUrl,
@@ -99,13 +104,21 @@ func perform(name string, values map[string]string) {
 	}
 }
 
-func isNotify(beforeStatusCode int, currentStatusCode int) bool {
+func isNotify(beforeStatusCode int, currentStatusCode int, onlyCheckOnTheOrderOf100 bool) bool {
 	if beforeStatusCode == NOT_FOUND_KEY {
 		return false
 	}
 
-	if beforeStatusCode != currentStatusCode {
-		return true
+	if onlyCheckOnTheOrderOf100 {
+		if beforeStatusCode/100 == currentStatusCode/100 {
+			return false
+		}
+
+	} else {
+		if beforeStatusCode == currentStatusCode {
+			return false
+		}
 	}
-	return false
+
+	return true
 }

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func perform(name string, values map[string]string) {
 		panic(err)
 	}
 
-	if beforeStatusCode != NOT_FOUND_KEY && beforeStatusCode != currentStatusCode {
+	if isNotify(beforeStatusCode, currentStatusCode) {
 		// When status code changes from the previous, notify
 		param := PostStatusParam{
 			CheckUrl:          checkUrl,
@@ -97,4 +97,15 @@ func perform(name string, values map[string]string) {
 		}
 		notifier.PostStatus(&param)
 	}
+}
+
+func isNotify(beforeStatusCode int, currentStatusCode int) bool {
+	if beforeStatusCode == NOT_FOUND_KEY {
+		return false
+	}
+
+	if beforeStatusCode != currentStatusCode {
+		return true
+	}
+	return false
 }

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func perform(name string, values map[string]string) {
 	}
 
 	onlyCheckOnTheOrderOf100 := false
-	if values["only_check_on_the_order_of_100"] == "true" {
+	if values["check_only_top_of_status_code"] == "true" {
 		onlyCheckOnTheOrderOf100 = true
 	}
 
@@ -104,12 +104,12 @@ func perform(name string, values map[string]string) {
 	}
 }
 
-func isNotify(beforeStatusCode int, currentStatusCode int, onlyCheckOnTheOrderOf100 bool) bool {
+func isNotify(beforeStatusCode int, currentStatusCode int, checkOnlyTopOfStatusCode bool) bool {
 	if beforeStatusCode == NOT_FOUND_KEY {
 		return false
 	}
 
-	if onlyCheckOnTheOrderOf100 {
+	if checkOnlyTopOfStatusCode {
 		if beforeStatusCode/100 == currentStatusCode/100 {
 			return false
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type isNotifyFixture struct {
+	beforeStatusCode  int
+	currentStatusCode int
+	expected          bool
+}
+
+var isNotifyFixtures = []isNotifyFixture{
+	{NOT_FOUND_KEY, 200, false},
+	{200, 200, false},
+	{200, 500, true},
+	{500, 501, true},
+}
+
+func TestIsNotify(t *testing.T) {
+	for _, fixture := range isNotifyFixtures {
+		actual := isNotify(fixture.beforeStatusCode, fixture.currentStatusCode)
+		assert.Equal(t, fixture.expected, actual)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -6,21 +6,28 @@ import (
 )
 
 type isNotifyFixture struct {
-	beforeStatusCode  int
-	currentStatusCode int
-	expected          bool
+	onlyCheckOnTheOrderOf100 bool
+	beforeStatusCode         int
+	currentStatusCode        int
+	expected                 bool
 }
 
 var isNotifyFixtures = []isNotifyFixture{
-	{NOT_FOUND_KEY, 200, false},
-	{200, 200, false},
-	{200, 500, true},
-	{500, 501, true},
+	{false, NOT_FOUND_KEY, 200, false},
+	{false, 200, 200, false},
+	{false, 200, 500, true},
+	{false, 500, 501, true},
+	{false, 200, 201, true},
+	{true, NOT_FOUND_KEY, 200, false},
+	{true, 200, 200, false},
+	{true, 200, 500, true},
+	{true, 500, 501, false},
+	{true, 200, 201, false},
 }
 
 func TestIsNotify(t *testing.T) {
 	for _, fixture := range isNotifyFixtures {
-		actual := isNotify(fixture.beforeStatusCode, fixture.currentStatusCode)
+		actual := isNotify(fixture.beforeStatusCode, fixture.currentStatusCode, fixture.onlyCheckOnTheOrderOf100)
 		assert.Equal(t, fixture.expected, actual)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 type isNotifyFixture struct {
-	onlyCheckOnTheOrderOf100 bool
+	checkOnlyTopOfStatusCode bool
 	beforeStatusCode         int
 	currentStatusCode        int
 	expected                 bool
@@ -27,7 +27,7 @@ var isNotifyFixtures = []isNotifyFixture{
 
 func TestIsNotify(t *testing.T) {
 	for _, fixture := range isNotifyFixtures {
-		actual := isNotify(fixture.beforeStatusCode, fixture.currentStatusCode, fixture.onlyCheckOnTheOrderOf100)
+		actual := isNotify(fixture.beforeStatusCode, fixture.currentStatusCode, fixture.checkOnlyTopOfStatusCode)
 		assert.Equal(t, fixture.expected, actual)
 	}
 }

--- a/test/config.yml
+++ b/test/config.yml
@@ -10,6 +10,6 @@ name2:
   api_token: "AAAAAAAA"
   room_id: 111111
 name3:
-  only_check_on_the_order_of_100: true
+  check_only_top_of_status_code: true
 name4:
-  only_check_on_the_order_of_100: false
+  check_only_top_of_status_code: false

--- a/test/config.yml
+++ b/test/config.yml
@@ -9,3 +9,7 @@ name2:
   type: chatwork
   api_token: "AAAAAAAA"
   room_id: 111111
+name3:
+  only_check_on_the_order_of_100: true
+name4:
+  only_check_on_the_order_of_100: false


### PR DESCRIPTION
# Example
When before status code: 501 and current status code: 502

* `check_only_top_of_status_code` is `true` : don't notify
* `check_only_top_of_status_code` is `false` : notify

