### PR TITLE
Drop golang 1.7 and CI against 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.7
   - 1.8
   - tip
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 sudo: false
 go:
   - 1.8
+  - 1.9
   - tip
 before_install:
   - go get -u github.com/golang/dep/cmd/dep


### PR DESCRIPTION
https://travis-ci.org/sue445/zatsu_monitor/jobs/270759386 is failed