### PR TITLE
fix slack notifier slackExpectedKeys for webhook compatible

### DIFF
--- a/slack_notifier.go
+++ b/slack_notifier.go
@@ -6,7 +6,7 @@ import (
 	"github.com/bluele/slack"
 )
 
-var slackExpectedKeys = []string{"type", "api_token", "channel"}
+var slackExpectedKeys = []string{"type", "check_url", "channel"}
 
 // SlackNotifier represents notifier for Slack
 type SlackNotifier struct {


### PR DESCRIPTION
I tried to use webhook notification for Slack, but not worked.
I think [slackExpectedKeys change](https://github.com/sue445/zatsu_monitor/pull/42/commits/fbc14b93e8843bd1a503f1263c3b9cb5f48faa30#diff-1c0fc0e1bd4fcd4173730ae4b343f417L8) is not check_url but api_token.
Applying this change works fine for me