### PR TITLE
use 'Zatsu_Monitor/:verion(:revision)' as UA

### DIFF
--- a/util.go
+++ b/util.go
@@ -4,7 +4,13 @@ import "net/http"
 
 // GetStatusCode checks and returns status code for URL
 func GetStatusCode(url string) (int, error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Add("User-Agent", "Zatsu_Monitor/"+Version+"("+Revision+")")
+
+	resp, err := http.DefaultClient.Do(req)
 
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
I saw `Go-http-client/:go_version` as UA in http server log, I could not understand what it is immediately.
So use unique UA for understandability