### PR TITLE
Fix dependabot error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/sue445/zatsu_monitor
 
 go 1.21
+toolchain go1.21.0
 
 require (
 	github.com/bluele/slack v0.0.0-20180528010058-b4b4d354a079


### PR DESCRIPTION
```
go: downloading go1.21 (linux/amd64)
go: download go1.21 for linux/amd64: toolchain not available
```

https://github.com/orgs/community/discussions/65431#discussioncomment-6875620